### PR TITLE
ref #4: Renamed some tests so we can now what they are supposed to be testing only by looking at the name. Added some comments inside tests to make it more clear. Remove duplications and not used stuff inside tests.

### DIFF
--- a/src/TweetNaCl.Tests/LibsodiumTests.cs
+++ b/src/TweetNaCl.Tests/LibsodiumTests.cs
@@ -64,7 +64,7 @@ namespace NaCl.Tests
 
         /* API requires first 32 bytes to be 0 */
         static readonly Byte[] m = 
-            { 0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+            {   0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
                 0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
                 0,    0,    0,    0,    0,    0,    0,    0,    0xbe, 0x07, 0x5f, 0xc5,
                 0x3c, 0x81, 0xf2, 0xd5, 0xcf, 0x14, 0x13, 0x16, 0xeb, 0xeb, 0x0c, 0x7b,

--- a/src/TweetNaCl.Tests/TweetNaClTests.cs
+++ b/src/TweetNaCl.Tests/TweetNaClTests.cs
@@ -41,22 +41,25 @@ namespace NaCl.Tests
     public class TweetNaClTests
     {
         [Test]
-        public void TestForRandomBytesGeneration()
+        public void RandomBytesGeneration_Should_Maintain_Length()
         {
-            Byte[] b200 = new Byte[200];
-            Byte[] b100 = new Byte[100];
-            Byte[] b10 = new Byte[10];
+            //Arrange
             Byte[] b1 = new Byte[1];
+            Byte[] b10 = new Byte[10];
+            Byte[] b100 = new Byte[100];
+            Byte[] b200 = new Byte[200];
 
-            TweetNaCl.RandomBytes(b10);
+            //Act
             TweetNaCl.RandomBytes(b1);
+            TweetNaCl.RandomBytes(b10);
             TweetNaCl.RandomBytes(b100);
             TweetNaCl.RandomBytes(b200);
 
-            String text10 =  Encoding.ASCII.GetString(b10);
+            //Assert
+            String text1 = Encoding.ASCII.GetString(b1);
+            String text10 = Encoding.ASCII.GetString(b10);
             String text100 = Encoding.ASCII.GetString(b100);
             String text200 = Encoding.ASCII.GetString(b200);
-            String text1 = Encoding.ASCII.GetString(b1);
 
             Assert.AreEqual(1, text1.Length);
             Assert.AreEqual(10, text10.Length);
@@ -65,8 +68,9 @@ namespace NaCl.Tests
         }
 
         [Test]
-        public void TestForCryptoScalarmult()
+        public void CryptoScalarmult_Should_Success()
         {
+            //Arrange
             Byte[] n = new Byte[TweetNaCl.ScalarmultBytes];
             Byte[] p = new Byte[TweetNaCl.ScalarBytes];
             Byte[] q = new Byte[TweetNaCl.ScalarmultBytes];
@@ -74,159 +78,165 @@ namespace NaCl.Tests
             TweetNaCl.RandomBytes(n);
             TweetNaCl.RandomBytes(p);
 
+            //Act
             q = TweetNaCl.CryptoScalarmult(n, p);
+
+            //Assert
             Assert.AreEqual(Encoding.ASCII.GetString(q).Length, 32, "wrong size for resulting group element q.");
         }
 
         [Test]
-        public void TestForCryptoScalarmultBase()
+        public void CryptoBoxKeypair_Should_Success()
         {
-            Byte[] n = new Byte[TweetNaCl.ScalarmultBytes];
-            Byte[] p = new Byte[TweetNaCl.ScalarBytes];
-            Byte[] q = new Byte[TweetNaCl.ScalarmultBytes];
+            //Arrange
+            Byte[] pk = new Byte[TweetNaCl.BoxPublicKeyBytes];
+            Byte[] sk = new Byte[TweetNaCl.BoxSecretKeyBytes];
 
-            TweetNaCl.RandomBytes(n);
-            TweetNaCl.RandomBytes(p);
+            //Act
+            pk = TweetNaCl.CryptoBoxKeypair(sk);
 
-            q = TweetNaCl.CryptoScalarmult(n, p);
-            Assert.AreEqual(Encoding.ASCII.GetString(q).Length, 32, "wrong size for resulting group element q.");
+            //Assert
+            Assert.AreEqual(Encoding.ASCII.GetString(pk).Length, 32, "key generation failed.");
         }
 
         [Test]
-        public void TestForGenerateEncryptionKeyPair()
+        public void CryptoBoxBeforenm_MessageEncryption_Should_Success()
         {
+            //Arrange
             Byte[] pk = new Byte[TweetNaCl.BoxPublicKeyBytes];
             Byte[] sk = new Byte[TweetNaCl.BoxSecretKeyBytes];
 
             pk = TweetNaCl.CryptoBoxKeypair(sk);
-            Assert.AreEqual(Encoding.ASCII.GetString(pk).Length, 32, "key generation failed.");
 
-            String pk64 = Convert.ToBase64String(pk);
-            String sk64 = Convert.ToBase64String(sk);
+            //Act
+            var k = TweetNaCl.CryptoBoxBeforenm(pk, sk);
+
+            //Assert
+            Assert.AreEqual(k.Length, TweetNaCl.BoxBeforenmBytes, "generation of K for encryption failed.");
         }
 
         [Test]
-        public void TestForMessageEncryptionWithCryptoBoxBeforenm()
+        public void CryptoBoxAfternm_MessageEncryption_Should_Success()
         {
-            Byte[] pk = new Byte[TweetNaCl.BoxPublicKeyBytes];
-            Byte[] sk = new Byte[TweetNaCl.BoxSecretKeyBytes];
-
-            pk = TweetNaCl.CryptoBoxKeypair(sk);
-            Assert.AreEqual(Encoding.ASCII.GetString(pk).Length, 32, "key generation failed.");
-
-            String message = "test";
-            Byte[] bMessage = Encoding.UTF8.GetBytes(message);
-            Byte[] paddedMessage = new Byte[TweetNaCl.BoxZeroBytes + bMessage.Length];
-            Byte[] encMessage = new Byte[paddedMessage.Length];
-            Byte[] decMessage = new Byte[encMessage.Length];
-            Byte[] nonce = new Byte[TweetNaCl.BoxNonceBytes];
-
-            TweetNaCl.RandomBytes(nonce);
-
-            String pubKey = Encoding.ASCII.GetString(pk);
-            String secKey = Encoding.ASCII.GetString(sk);
-
-            var k = TweetNaCl.CryptoBoxBeforenm( pk, sk);
-            Assert.AreEqual(k.Length, TweetNaCl.BoxBeforenmBytes,"generation of K for encryption failed.");
-        }
-
-        [Test]
-        public void TestForMessageEncryptionWithCryptoBoxAfternm()
-        {
+            //Arrange
             String message = "test";
             Byte[] bMessage = Encoding.UTF8.GetBytes(message);
             Byte[] pk = new Byte[TweetNaCl.BoxPublicKeyBytes];
             Byte[] sk = new Byte[TweetNaCl.BoxSecretKeyBytes];
             Byte[] nonce = new Byte[TweetNaCl.BoxNonceBytes];
-
-            var result = 1;
+            TweetNaCl.RandomBytes(nonce);
 
             pk = TweetNaCl.CryptoBoxKeypair(sk);
-            Assert.AreEqual(Encoding.ASCII.GetString(pk).Length, 32, "key generation failed.");
-
-            TweetNaCl.RandomBytes(nonce);
-            Assert.AreNotEqual(result, -1, "randombytes generation failed.");
 
             var k = TweetNaCl.CryptoBoxBeforenm(pk, sk);
 
+            //Act
             var encMessage = TweetNaCl.CryptoBoxAfternm(bMessage, nonce, k);
+
+            //Assert
             Assert.AreEqual(encMessage.Length, bMessage.Length + TweetNaCl.BoxBoxZeroBytes, "encryption failed.");
         }
 
         [Test]
-        public void TestForMessageEncryptionWithCryptoBoxOpenAfternm()
+        public void CryptoBoxOpenAfternm_Decryption_Should_Success()
         {
-            String message = "test";
-            Byte[] bMessage = Encoding.UTF8.GetBytes(message);
+            //Arrange
+            String expectedMessage = "test";
+            Byte[] bMessage = Encoding.UTF8.GetBytes(expectedMessage);
             Byte[] pk = new Byte[TweetNaCl.BoxPublicKeyBytes];
             Byte[] sk = new Byte[TweetNaCl.BoxSecretKeyBytes];
             Byte[] nonce = new Byte[TweetNaCl.BoxNonceBytes];
 
             pk = TweetNaCl.CryptoBoxKeypair(sk);
-
             TweetNaCl.RandomBytes(nonce);
-
             var k = TweetNaCl.CryptoBoxBeforenm(pk, sk);
-            Assert.AreEqual(k.Length, TweetNaCl.BoxBeforenmBytes, "K generation for encryption failed.");
 
+            //Act
             var encMessage = TweetNaCl.CryptoBoxAfternm(bMessage, nonce, k);
-            Assert.AreEqual(encMessage.Length, bMessage.Length + TweetNaCl.BoxBoxZeroBytes, "encryption failed.");
-
             var decMessage = TweetNaCl.CryptoBoxOpenAfternm(encMessage, nonce, k);
+
+            //Assert
             Assert.AreEqual(decMessage.Length, bMessage.Length, "decryption failed.");
             Assert.AreEqual(decMessage, bMessage, "decryption failed.");
+
+            var resultMessage = Encoding.ASCII.GetString(decMessage);
+            Assert.AreEqual(resultMessage, expectedMessage, "decryption failed.");
         }
 
 
         [Test]
-        public void TestForMessageEncryption()
+        public void CryptoBox_MessageEncryption_Should_Success()
         {
+            //Arrange
             String message = "test";
             Byte[] bMessage = Encoding.UTF8.GetBytes(message);
             Byte[] pk = new Byte[TweetNaCl.BoxPublicKeyBytes];
             Byte[] sk = new Byte[TweetNaCl.BoxSecretKeyBytes];
             Byte[] nonce = new Byte[TweetNaCl.BoxNonceBytes];
-            Byte[] k = new Byte[TweetNaCl.BoxBeforenmBytes];
 
             pk = TweetNaCl.CryptoBoxKeypair(sk);
             TweetNaCl.RandomBytes(nonce);
 
+            //Act
             var encMessage = TweetNaCl.CryptoBox(bMessage, nonce, pk, sk);
+
+            //Assert
             Assert.AreEqual(encMessage.Length, bMessage.Length + TweetNaCl.BoxBoxZeroBytes, "encryption failed.");
         }
 
         [Test]
-        public void TestForMessageDecryptionDifferentKeyPair()
+        public void CryptoBoxOpen_DecryptionDifferentKeyPair_Should_Success()
         {
+            //Arrange
             Byte[] apk = new Byte[TweetNaCl.BoxPublicKeyBytes];
             Byte[] ask = new Byte[TweetNaCl.BoxSecretKeyBytes];
 
             Byte[] bpk = new Byte[TweetNaCl.BoxPublicKeyBytes];
             Byte[] bsk = new Byte[TweetNaCl.BoxSecretKeyBytes];
 
-            String message = "test";
-            Byte[] bMessage = Encoding.UTF8.GetBytes(message);
+            String expectedMessage = "test";
+            Byte[] bMessage = Encoding.UTF8.GetBytes(expectedMessage);
             Byte[] nonce = new Byte[TweetNaCl.BoxNonceBytes];
-            Byte[] k = new Byte[TweetNaCl.BoxBeforenmBytes];
 
             apk = TweetNaCl.CryptoBoxKeypair(ask);
             bpk = TweetNaCl.CryptoBoxKeypair(bsk);
 
             TweetNaCl.RandomBytes(nonce);
 
+            //Act
             var encMessage = TweetNaCl.CryptoBox(bMessage, nonce, bpk, ask);
-            Assert.AreEqual(encMessage.Length, bMessage.Length + TweetNaCl.BoxBoxZeroBytes, "encryption failed.");
-
-
             var decMessage = TweetNaCl.CryptoBoxOpen(encMessage, nonce, apk, bsk);
-            Assert.AreEqual(decMessage.Length, bMessage.Length, "encryption failed.");
+
+            //Assert
+            Assert.AreEqual(encMessage.Length, bMessage.Length + TweetNaCl.BoxBoxZeroBytes, "encryption failed.");
+            Assert.AreEqual(decMessage.Length, bMessage.Length, "decryption failed.");
+
+            var resultMessage = Encoding.ASCII.GetString(decMessage);
+            Assert.AreEqual(resultMessage, expectedMessage, "decryption failed.");
         }
 
         [Test]
-        public void TestForMessageDecryptionSecretBox()
+        public void CryptoSecretBox_Should_Success()
         {
-            Byte[] bsk = new Byte[TweetNaCl.SecretBoxNonceBytes];
+            //Arrange
+            String message = "test";
+            Byte[] bMessage = Encoding.UTF8.GetBytes(message);
+            Byte[] sk = new Byte[TweetNaCl.SecretBoxKeyBytes];
+            Byte[] nonce = new Byte[TweetNaCl.SecretBoxNonceBytes];
+            TweetNaCl.RandomBytes(sk);
+            TweetNaCl.RandomBytes(nonce);
 
+            //Act
+            var encMessage = TweetNaCl.CryptoSecretBox(bMessage, nonce, sk);
+
+            //Assert
+            Assert.AreEqual(encMessage.Length, bMessage.Length + TweetNaCl.BoxBoxZeroBytes, "encryption failed.");
+        }
+
+        [Test]
+        public void CryptoSecretBoxOpen_Decryption_Should_Success()
+        {
+            //Arrange
             String message = "test";
             Byte[] bMessage = Encoding.UTF8.GetBytes(message);
             Byte[] sk = new Byte[TweetNaCl.SecretBoxKeyBytes];
@@ -236,61 +246,70 @@ namespace NaCl.Tests
             TweetNaCl.RandomBytes(nonce);
 
             var encMessage = TweetNaCl.CryptoSecretBox(bMessage, nonce, sk);
-            Assert.AreEqual(encMessage.Length, bMessage.Length + TweetNaCl.BoxBoxZeroBytes, "encryption failed.");
 
+            //Act
             var decMessage = TweetNaCl.CryptoSecretBoxOpen(encMessage, nonce, sk);
             Assert.AreEqual(decMessage.Length, bMessage.Length, "decryption failed.");
             Assert.AreEqual(decMessage, bMessage, "decryption failed.");
         }
 
         [Test]
-        public void TestForMessageHashing()
+        public void CryptoHash_MessageHashing_Should_Success()
         {
+            //Arrange
             String message = "test";
             Byte[] bMessage = Encoding.UTF8.GetBytes(message);
             Byte[] hsh1 = new Byte[TweetNaCl.HashBytes];
             Byte[] hsh2 = new Byte[TweetNaCl.HashBytes];
 
-            var result = -10;
+            var firstResult = 0;
+            var secontResult = 0;
 
-            TweetNaCl.CryptoHash(hsh1, bMessage, bMessage.Length);
-            Assert.AreNotEqual(result, -1, "First hashing call for message generation failed.");
+            //Act
+            firstResult = TweetNaCl.CryptoHash(hsh1, bMessage, bMessage.Length);
+            secontResult = TweetNaCl.CryptoHash(hsh2, bMessage, bMessage.Length);
 
-            TweetNaCl.CryptoHash(hsh2, bMessage, bMessage.Length);
-            Assert.AreNotEqual(result, -1, "Second hashing call for message generation failed.");
-
-
+            //Assert
+            Assert.AreNotEqual(firstResult, -1, "First hashing call for message generation failed.");
+            Assert.AreNotEqual(secontResult, -1, "Second hashing call for message generation failed.");
             Assert.AreEqual(hsh1, hsh2, "hash for message are not equal.");
         }
 
         [Test]
-        public void TestForMessageSignKeypair()
+        public void CryptoSignKeypair_Generation_Should_Success()
         {
-            
+            //Arrange
             Byte[] ssk = new Byte[TweetNaCl.SignSecretKeyBytes];
 
+            //Act
             Byte[] spk = TweetNaCl.CryptoSignKeypair(ssk);
+
+            //Assert
             Assert.AreEqual(Encoding.ASCII.GetString(spk).Length, 32, "Public Key for message sign generation failed.");
             Assert.AreEqual(Encoding.ASCII.GetString(ssk).Length, 64, "Secret Key for message sign generation failed.");
         }
 
         [Test]
-        public void TestForMessageSign()
+        public void CryptoSign_Should_Success()
         {
+            //Arrange
             String message = "test";
             Byte[] bMessage = Encoding.UTF8.GetBytes(message);
             Byte[] ssk = new Byte[TweetNaCl.SignSecretKeyBytes];
             Byte[] sMessage;
 
+            //Act
             var spk = TweetNaCl.CryptoSignKeypair(ssk);
-
             sMessage = TweetNaCl.CryptoSign(bMessage, ssk);
+
+            //Assert
             Assert.AreEqual(Encoding.ASCII.GetString(sMessage).Length, bMessage.Length + TweetNaCl.SignBytes, "Message sign failed.");
         }
 
         [Test]
-        public void TestForMessageSignOpen()
+        public void CryptoSignOpen_Should_Success()
         {
+            //Arrange
             String message = "test";
             Byte[] bMessage = Encoding.UTF8.GetBytes(message);
             Byte[] ssk = new Byte[TweetNaCl.SignSecretKeyBytes];
@@ -299,8 +318,8 @@ namespace NaCl.Tests
 
             var spk = TweetNaCl.CryptoSignKeypair(ssk);
             sMessage = TweetNaCl.CryptoSign(bMessage, ssk);
-            Assert.AreEqual(sMessage.Length, bMessage.Length + TweetNaCl.SignBytes, "Message sign failed.");
 
+            //Act
             cMessage = TweetNaCl.CryptoSignOpen(sMessage, spk);
             Assert.AreEqual(cMessage.Length, bMessage.Length, "Message sign verification failed.");
             Assert.AreEqual(Encoding.UTF8.GetString(cMessage), message, "Messages sign verification failed.");


### PR DESCRIPTION
Renamed some tests so we can now what they are supposed to be testing only by looking at the name.
Added some comments inside tests to make it more clear.
Removed duplications and not used stuff inside tests.